### PR TITLE
csplib_033_word_design: description says 'as large a set' but the model is satisfaction over num_words

### DIFF
--- a/dataset/csplib_033_word_design/csplib_033_word_design.cpmpy.py
+++ b/dataset/csplib_033_word_design/csplib_033_word_design.cpmpy.py
@@ -4,7 +4,7 @@
 # Source description: https://www.csplib.org/Problems/prob033/
 
 """
-Find as large a set \( S \) of strings (words) of length `n` over the alphabet \( W = \{ A,C,G,T \} \) with the following properties:
+Find a set \( S \) of `num_words` strings (words) of length `n` over the alphabet \( W = \{ A,C,G,T \} \) with the following properties:
 
 - Each word in \( S \) has 4 symbols from \{ C,G \};
 - Each pair of distinct words in \( S \) differ in at least 4 positions; and


### PR DESCRIPTION
Follow-up to the `csplib_033_word_design` defect discussed by email. Commit d86b03a
already fixed the core of it — `n` is now the word length in both the description and
the model, with `num_words` decoupled and instance-driven. Thanks for that; this PR
closes the one **residual** mismatch, and it is **description-only, one line**:

The prose still opens with an optimization the model doesn't implement, and never
mentions that the set size is a given input:

> "Find **as large a set** \( S \) of strings (words) of length `n` …"

while the model is pure satisfaction (`model.solve()`, no objective) over exactly
`num_words` words. A solver that faithfully models the prose adds a maximization
that the ground truth doesn't have.

Diff (docstring line 7 only; all code byte-identical):
```diff
-Find as large a set \( S \) of strings (words) of length `n` over the alphabet \( W = \{ A,C,G,T \} \) with the following properties:
+Find a set \( S \) of `num_words` strings (words) of length `n` over the alphabet \( W = \{ A,C,G,T \} \) with the following properties:
```

The "For example, when n=8 …" clause later in the description is untouched — with
`n` now meaning length again, it is correct as written.

Verified before submitting: all five current instances
(`n = 8..12, num_words = 8`) remain SAT with sub-second solves; since the change is
prose-only, no submission's grade can change.

**Why not implement the maximization instead** (the true CSPLib prob033, maximize
|S|)? It isn't gradeable here — eval matches the ground truth's solved optimum, and
the known optimum for length-8 word design is 112, which is neither reachable nor
provable within eval timeouts (measured: a `maximize(sum(used))` CP-SAT formulation
finds nothing usable at 112 slots in 30s). Fixed-count satisfaction is the gradeable
formulation, so aligning the prose to it is the right fix.
